### PR TITLE
Add Raspbian compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ Enables displaying CPU temperature in Tmux status-right and status-left. Configu
 
 ## Installation
 
+### Using hardware monitoring chips
+
 Requires lm_sensors package to be installed and configured.
+[info](https://github.com/lm-sensors/lm-sensors/blob/master/README)
 
 ```
-sudo apt-get install lm-sensors 
+sudo apt-get install lm-sensors
 
 # After installation type the following in terminal
 sudo sensors-detect
@@ -17,6 +20,11 @@ sudo sensors-detect
 # You may also need to run
 sudo service kmod start
 ```
+
+### Raspberry Pi Raspbian
+
+This plugin uses `vcgencmd measure_temp` command on RPi Raspbian to get CPU temperature.
+Should be compatible with other RPi distros with `vcgencmd` available.
 
 ### Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 

--- a/scripts/temp_cpu.sh
+++ b/scripts/temp_cpu.sh
@@ -6,17 +6,25 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 print_cpu_temp() {
+  local temp
+  local units=$1
+
+  # try with very common lm-sensors package
   if command_exists "sensors"; then
-    local units=$1
-    local temp
     temp=$(sensors | sed '/^[^Package]/d' | sed '/^\s*$/d' | tail -n 1 | awk '{a=$4} END {printf("%f", a)}')
-    if [ "$units" = "F" ]; then
-      temp=$(celsius_to_fahrenheit "$temp")
-    fi
-    printf "%3.0fº%s" "$temp" "$units"
+
+  # try if this is Raspberry Pi
+  elif command_exists "vcgencmd"; then
+    temp=$(vcgencmd measure_temp | tr -d -c 0-9.)
+
   else
     echo "no sensors found"
   fi
+
+  if [ "$units" = "F" ]; then
+    temp=$(celsius_to_fahrenheit "$temp")
+  fi
+  printf "%3.0fº%s" "$temp" "$units"
 }
 
 main() {


### PR DESCRIPTION
RPi distros usually provides vcgencmd command that can be used for
getting CPU Temperature stats and many more.

Signed-off-by: Krzysztof Romanowski <krzysztof.romanowski94@gmail.com>