### PR TITLE
Support mac with Apple Sillicon (M1 chip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Should be compatible with other RPi distros with `vcgencmd` available.
 
 ### On macOS
 
-This plugin uses [lavoiesl/osx-cpu-temp](https://github.com/lavoiesl/osx-cpu-temp).
+This plugin uses [narugit/smctemp](https://github.com/narugit/smctemp).
 
 ```console
-$ git clone https://github.com/lavoiesl/osx-cpu-temp /tmp/osx-cpu-temp
-$ (cd /tmp/osx-cpu-temp && make && sudo make install)
-$ rm -rf /tmp/osx-cpu-temp
+$ git clone https://github.com/narugit/smctemp
+$ cd smctemp
+$ sudo make install
 ```
 
 ## Installation

--- a/scripts/temp_cpu.sh
+++ b/scripts/temp_cpu.sh
@@ -30,9 +30,8 @@ print_cpu_temp() {
     done
     # remove leading and trailing whitespace
     echo "$temp_string" | awk 'BEGIN{OFS=" "}$1=$1{print $0}'
-  elif command_exists "osx-cpu-temp"; then
-    local temp
-    temp=$(osx-cpu-temp | grep -o "[0-9]*\.[0-9]")
+  elif command_exists "smctemp"; then
+    temp=$(smctemp -c)
   else
     echo "no sensors found"
   fi


### PR DESCRIPTION
### Summary
- Support macOS with Apple Sillicon by using [narugit/smctemp](https://github.com/narugit/smctemp).

### Background
- Actually, [lavoiesl/osx-cpu-temp](https://github.com/lavoiesl/osx-cpu-temp) does not work on macOS with M1 chip. (https://github.com/lavoiesl/osx-cpu-temp/issues/38)
- It seems that [lavoiesl/osx-cpu-temp](https://github.com/lavoiesl/osx-cpu-temp) hasn't been maintained for about two years, so I have tried to make [narugit/smctemp](https://github.com/narugit/smctemp).

### Operation Verification
I have checked in
- macOS Big Sur 11.4 (Intel(R) Core(TM) i7-8557)
- macOS Monterey 12.2.1 (Apple M1 Pro)

#### tmux.conf
```
set-option -g status-right "temp: #{temp_cpu}"
```

#### Result (Screenshot)
Actually, I have set format specifier %3.1f, not %3.0f in my environment ([narugit/tmux-temp/scripts/temp_cpu.sh#L42](https://github.com/narugit/tmux-temp/blob/0d7f119cbb5137e9424bad4d115b365b554ca991/scripts/temp_cpu.sh#L42))
##### macOS Big Sur 11.4 (Intel(R) Core(TM) i7-8557)
![image](https://user-images.githubusercontent.com/28133383/155343270-9e2c8f01-f3f8-4ba4-bdbe-4474a2b5fb0a.png)

##### macOS Monterey 12.2.1 (Apple M1 Pro)
![image](https://user-images.githubusercontent.com/28133383/155343437-bb103efa-15bd-4b66-b088-a4cfca7c1f67.png)

